### PR TITLE
Added support for configurable hybris installation path.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV GOSU_VERSION 1.9
 ENV JAVA_HOME /usr/lib/jvm/java-${VERSION}-oracle
 ENV JRE_HOME ${JAVA_HOME}/jre
 
+ARG HYBRIS_HOME=/home/hybris
+
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/stefanleh/hybris-base-image"
@@ -43,14 +45,15 @@ RUN set -x \
     && gosu nobody true
 
 # set the PLATFORM_HOME environment variable used by hybris
-ENV PLATFORM_HOME=/home/hybris/bin/platform/
+ENV PLATFORM_HOME=${HYBRIS_HOME}/bin/platform/
 ENV PATH=$PLATFORM_HOME:$PATH
+ENV HYBRIS_HOME=${HYBRIS_HOME}
 
 # add hybris user
-RUN useradd -d /home/hybris -u 1000 -m -s /bin/bash hybris
+RUN useradd -d ${HYBRIS_HOME} -u 1000 -m -s /bin/bash hybris
 
 # define hybris home dir as volume
-VOLUME /home/hybris
+VOLUME ${HYBRIS_HOME}
 
 # expose hybris ports
 EXPOSE 9001
@@ -67,9 +70,9 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # copy the update system config to image
-COPY updateRunningSystem.config /home/hybris/updateRunningSystem.config
+COPY updateRunningSystem.config ${HYBRIS_HOME}/updateRunningSystem.config
 
-WORKDIR /home/hybris
+WORKDIR ${HYBRIS_HOME}
 
 # set entrypoint of container
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Also the default Solr server port ``8983`` is exposed.
 If you like to debug via your IDE on the running server you can use the exposed ``8000`` port.
 
 #### Volumes
-The hybris home directory `/home/hybris` is marked as volume.
+The hybris home directory `/home/hybris` is marked as volume. You can override it by setting the `HYBRIS_HOME` variable.
 
 #### How to add your code
 
@@ -55,7 +55,7 @@ If you want you can copy unzipped content too, but this will bloat the images yo
 	MAINTAINER You <you.yourname@yourdomain.com>
 
 	# copy the build packages over
-	COPY hybrisServer*.zip /home/hybris/
+	COPY hybrisServer*.zip $HYBRIS_HOME
 
 #### Configuration support
 
@@ -111,10 +111,10 @@ After you got your config you can include it into your own application image via
 	MAINTAINER You <you.yourname@yourdomain.com>
 
 	# copy the build packages over
-	COPY hybrisServer*.zip /home/hybris/
+	COPY hybrisServer*.zip $HYBRIS_HOME
 
 	# copy the update system config to image
-	COPY updateRunningSystem.config /home/hybris/updateRunningSystem.config
+	COPY updateRunningSystem.config $HYBRIS_HOME/updateRunningSystem.config
 
 #### Hint
 
@@ -161,9 +161,9 @@ As the image is not intended for recompiling the hybris platform inside a contai
 	mv hybris/temp/hybris/hybrisServer/hybrisServer*.zip docker/
 	cd docker
 	echo "FROM stefanlehmann/hybris-base-image:latest
-	ENV PLATFORM_HOME=/home/hybris/bin/platform
+	ENV PLATFORM_HOME=\$HYBRIS_HOME/bin/platform
 	ENV PATH=\$PLATFORM_HOME:\$PATH
-	COPY hybrisServer*.zip /home/hybris/" >> Dockerfile
+	COPY hybrisServer*.zip $HYBRIS_HOME" >> Dockerfile
 	cat Dockerfile
 
 ##### Build the image (still in docker dir created before)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,13 +4,17 @@ export DOCKER_CONTAINER_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?
 
 if [ "$1" = 'run' ]; then
 
-    if [ ! -d "/home/hybris/bin" ]; then
+    if [ -z "$HYBRIS_HOME" ]; then
+        HYBRIS_HOME="/home/hybris"
+    fi
 
-        cd /home/hybris
+    if [ ! -d "$HYBRIS_HOME/config" ]; then
+
+        cd $HYBRIS_HOME
 
         # unzip the artifacts created by production ant target
         echo "Unzipping hybris production archives ..."
-        for z in hybrisServer*.zip; do unzip $z -d /home ; done
+        for z in hybrisServer*.zip; do unzip $z -d $(dirname $HYBRIS_HOME) ; done
 
         # add container ip to cluster configuration of hybris instance
         echo "cluster.broadcast.method.jgroups.tcp.bind_addr=$DOCKER_CONTAINER_IP" >> config/local.properties
@@ -39,7 +43,7 @@ if [ "$1" = 'run' ]; then
     cd ${PLATFORM_HOME}
 
     # fix ownership of files
-    chown -R hybris /home/hybris
+    chown -R hybris $HYBRIS_HOME
     chmod +x hybrisserver.sh
 
     # if initialize system is wanted we do it before starting the hybris server
@@ -55,7 +59,7 @@ if [ "$1" = 'run' ]; then
     	# set ant environment
     	source ./setantenv.sh
     	# run hybris update with predefined config
-    	gosu hybris ant updatesystem -DconfigFile=/home/hybris/updateRunningSystem.config
+    	gosu hybris ant updatesystem -DconfigFile=$HYBRIS_HOME/updateRunningSystem.config
     fi
 
     # run hybris commerce suite as user hybris


### PR DESCRIPTION
Added support for configurable hybris installation path. Having the installation path ending in `hybris` is still a requirement for the `entrypoint.sh` script because the Hybris Server archives contain the hybris directory as root of the directory structure. We can, of course, change this, but I consider that keeping the installation pack as close to original version is not a bad idea.
The justification for this pull request is to allow other installation directories, like `/opt/hybris`
